### PR TITLE
switch clipping maxima

### DIFF
--- a/src/surforama/app.py
+++ b/src/surforama/app.py
@@ -199,9 +199,9 @@ class QtSurforama(QWidget):
 
         vol_shape = self.volume.shape
 
-        new_positions[:, 0] = np.clip(new_positions[:, 0], 0, vol_shape[2] - 1)
+        new_positions[:, 0] = np.clip(new_positions[:, 0], 0, vol_shape[0] - 1)
         new_positions[:, 1] = np.clip(new_positions[:, 1], 0, vol_shape[1] - 1)
-        new_positions[:, 2] = np.clip(new_positions[:, 2], 0, vol_shape[0] - 1)
+        new_positions[:, 2] = np.clip(new_positions[:, 2], 0, vol_shape[2] - 1)
 
         self.color_values = new_colors
         self.vertices = new_positions


### PR DESCRIPTION
I think the volume dimensions need to be switched. With the current implementation, I get these "bent" membranes with triangles projected on a plane.

After changing the clipping dimensions, it looks good :)

<img width="389" alt="snap_bent_membrane" src="https://github.com/cellcanvas/surforama/assets/34575029/c231d8c4-a267-4957-a620-dd48ba554317">
<img width="389" alt="snap_straight_membrane" src="https://github.com/cellcanvas/surforama/assets/34575029/a39f2f85-78d0-4bfa-baa5-36b7df4a6aca">
