### PR TITLE
Add slider values & fix overflow errors

### DIFF
--- a/src/surforama/_cli.py
+++ b/src/surforama/_cli.py
@@ -64,7 +64,7 @@ def launch_surforama(
         # set up the viewer with the user-requested images
         if image_path is not None:
             # load the image if the path was passed
-            image = mrcfile.read(image_path)
+            image = mrcfile.read(image_path).astype(float)
             volume_layer = viewer.add_image(image)
         else:
             volume_layer = None

--- a/src/surforama/app.py
+++ b/src/surforama/app.py
@@ -199,9 +199,9 @@ class QtSurforama(QWidget):
 
         vol_shape = self.volume.shape
 
-        new_positions[:, 0] = np.clip(new_positions[:, 0], 0, vol_shape[2] - 1)
+        new_positions[:, 0] = np.clip(new_positions[:, 0], 0, vol_shape[0] - 1)
         new_positions[:, 1] = np.clip(new_positions[:, 1], 0, vol_shape[1] - 1)
-        new_positions[:, 2] = np.clip(new_positions[:, 2], 0, vol_shape[0] - 1)
+        new_positions[:, 2] = np.clip(new_positions[:, 2], 0, vol_shape[2] - 1)
 
         self.color_values = new_colors
         self.vertices = new_positions

--- a/src/surforama/app.py
+++ b/src/surforama/app.py
@@ -12,6 +12,7 @@ from napari.layers import Image, Surface
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QGroupBox,
+    QHBoxLayout,
     QLabel,
     QPushButton,
     QSlider,
@@ -58,6 +59,11 @@ class QtSurforama(QWidget):
         self.slider.setValue(0)
         self.slider.valueChanged.connect(self.slide_points)
         self.slider.setVisible(False)
+        self.slider_value = QLabel("0 vx", self)
+
+        self.sliderLayout = QHBoxLayout()
+        self.sliderLayout.addWidget(self.slider)
+        self.sliderLayout.addWidget(self.slider_value)
 
         # New slider for sampling depth
 
@@ -70,6 +76,11 @@ class QtSurforama(QWidget):
             self.update_colors_based_on_sampling
         )
         self.sampling_depth_slider.setVisible(False)
+        self.sampling_depth_value = QLabel("10", self)
+
+        self.sampling_depth_sliderLayout = QHBoxLayout()
+        self.sampling_depth_sliderLayout.addWidget(self.sampling_depth_slider)
+        self.sampling_depth_sliderLayout.addWidget(self.sampling_depth_value)
 
         # make the picking widget
         self.picking_widget = QtSurfacePicker(surforama=self, parent=self)
@@ -85,9 +96,9 @@ class QtSurforama(QWidget):
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self._layer_selection_widget.native)
         self.layout().addWidget(QLabel("Extend/contract surface"))
-        self.layout().addWidget(self.slider)
+        self.layout().addLayout(self.sliderLayout)
         self.layout().addWidget(QLabel("Surface Thickness"))
-        self.layout().addWidget(self.sampling_depth_slider)
+        self.layout().addLayout(self.sampling_depth_sliderLayout)
         self.layout().addWidget(self.picking_widget)
         self.layout().addWidget(self.point_writer_widget)
         self.layout().addStretch()
@@ -185,6 +196,7 @@ class QtSurforama(QWidget):
         self.color_values = new_colors
         self.vertices = new_positions
         self.update_mesh()
+        self.slider_value.setText(f"{shift} vx")
 
     def update_mesh(self):
         self.surface_layer.data = (
@@ -249,6 +261,7 @@ class QtSurforama(QWidget):
 
         self.color_values = new_colors
         self.update_mesh()
+        self.sampling_depth_value.setText(f"{value}")
 
 
 class QtSurfacePicker(QGroupBox):

--- a/src/surforama/app.py
+++ b/src/surforama/app.py
@@ -157,10 +157,10 @@ class QtSurforama(QWidget):
         point_values = self.volume[
             point_indices[:, 0], point_indices[:, 1], point_indices[:, 2]
         ]
-        normalized_values = (point_values - point_values.min()) / (
-            point_values.max() - point_values.min()
-        )
 
+        normalized_values = (point_values - point_values.min()) / (
+            point_values.max() - point_values.min() + np.finfo(float).eps
+        )
         return normalized_values
 
     def get_point_set(self):

--- a/src/surforama/data/_datasets.py
+++ b/src/surforama/data/_datasets.py
@@ -33,7 +33,7 @@ def thylakoid_membrane() -> (
     tomogram_path = _data_registry.fetch(
         "S1_M3b_StII_grow2_1_mesh_data.mrc", progressbar=True
     )
-    tomogram = mrcfile.read(tomogram_path)
+    tomogram = mrcfile.read(tomogram_path).astype(float)
 
     # get the mesh
     mesh_path = _data_registry.fetch(


### PR DESCRIPTION
This PR adds values of the current depth of the slider to the interface (see attached screenshot).
<img width="374" alt="slider_values" src="https://github.com/cellcanvas/surforama/assets/34575029/7ac66504-8f52-43cb-aa97-3a2a5659cb27">

I also encountered several overflow issues, as also mentioned here: https://github.com/cellcanvas/surforama/issues/22

This was due to the tomogram consisting of signed integer values and then substracting the minimum value during normalization (see highlighted code). I converted tomograms to float when loading them to fix this.