### PR TITLE
Add covid sample data and napari installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ inspired by [membranorama](https://github.com/dtegunov/membranorama)
 ![Screenshot of surforama showing a surface in the slice of a tomogram](surforama_screenshot.png)
 
 ## installation
-First, install napari. Then install surforama in the same environment.
+`surforama` requires the napari viewer. If you would like to install napari and surforama together in one line, you can use the following command:
 
-```python
+```bash
+pip install "surforama[napari]"
+```
+
+
+If you already have napari installed, you can directly install surforama in the same environment:
+
+```bash
 pip install surforama
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,8 @@ testing =
     pytest-cov
     pytest-qt
     tox
+napari =
+    napari[all]
 
 [options.package_data]
 * = *.yaml

--- a/src/surforama/data/_datasets.py
+++ b/src/surforama/data/_datasets.py
@@ -7,7 +7,7 @@ from napari.types import LayerDataTuple
 
 from surforama.io.mesh import read_obj_file
 
-_data_registry = pooch.create(
+_thylakoid_registry = pooch.create(
     path=pooch.os_cache("cellcanvas"),
     base_url="doi:10.5281/zenodo.10814409",
     registry={
@@ -17,6 +17,15 @@ _data_registry = pooch.create(
         "S1_M3c_StOI_grow2_1_mesh_data.mrc": "md5:296fbc48917c2baab7784a5ede6aae70",
         "S1_M3c_StOI_grow2_1_mesh_data.obj": "md5:076e6e8a825f67a24e28beba09edcf70",
         "S1_M3c_StOI_grow2_1_mesh_data_seg.mrc": "md5:878d4b3fc076dfc01e788cc08f9c9201",
+    },
+)
+
+_covid_registry = pooch.create(
+    path=pooch.os_cache("cellcanvas"),
+    base_url="doi:10.5281/zenodo.10837518",
+    registry={
+        "TS_004_dose-filt_lp50_bin8.rec": "md5:31914b3aa32c5656acf583f08a581f64",
+        "TS_004_dose-filt_lp50_bin8_membrain_model.obj": "md5:9e67ab9493096ce6455e244ca6b20220",
     },
 )
 
@@ -30,13 +39,13 @@ def thylakoid_membrane() -> (
     https://doi.org/10.7554/eLife.53740
     """
     # get the tomogram
-    tomogram_path = _data_registry.fetch(
+    tomogram_path = _thylakoid_registry.fetch(
         "S1_M3b_StII_grow2_1_mesh_data.mrc", progressbar=True
     )
     tomogram = mrcfile.read(tomogram_path).astype(float)
 
     # get the mesh
-    mesh_path = _data_registry.fetch(
+    mesh_path = _thylakoid_registry.fetch(
         "S1_M3b_StII_grow2_1_mesh_data.obj", progressbar=True
     )
     mesh_data = read_obj_file(mesh_path)
@@ -49,6 +58,41 @@ def _thylakoid_membrane_sample_data_plugin() -> List[LayerDataTuple]:
 
     # get the data
     tomogram, mesh_data = thylakoid_membrane()
+
+    return [
+        (tomogram, {"name": "tomogram"}, "image"),
+        (mesh_data, {"name": "mesh"}, "surface"),
+    ]
+
+
+def covid_membrane() -> (
+    Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray, np.ndarray]]
+):
+    """Fetch the covid membrane sample data.
+
+    Data originally from Ke et al., Nature, 2020.
+    https://doi.org/10.5281/zenodo.10837519
+    """
+    # get the tomogram
+    tomogram_path = _covid_registry.fetch(
+        "TS_004_dose-filt_lp50_bin8.rec", progressbar=True
+    )
+    tomogram = mrcfile.read(tomogram_path).astype(float)
+
+    # get the mesh
+    mesh_path = _covid_registry.fetch(
+        "TS_004_dose-filt_lp50_bin8_membrain_model.obj", progressbar=True
+    )
+    mesh_data = read_obj_file(mesh_path)
+
+    return tomogram, mesh_data
+
+
+def _covid_membrane_sample_data_plugin() -> List[LayerDataTuple]:
+    """napari sample data plugin for thylakoid membrane dataset."""
+
+    # get the data
+    tomogram, mesh_data = covid_membrane()
 
     return [
         (tomogram, {"name": "tomogram"}, "image"),

--- a/src/surforama/napari.yaml
+++ b/src/surforama/napari.yaml
@@ -12,6 +12,9 @@ contributions:
     - id: surforama.thylakoid
       python_name: surforama.data._datasets:_thylakoid_membrane_sample_data_plugin
       title: Thylakoid membrane
+    - id: surforama.covid
+      python_name: surforama.data._datasets:_covid_membrane_sample_data_plugin
+      title: Covid virion membrane
     - id: surforama.mesh_reader
       python_name: surforama.io._reader_plugin:mesh_reader_plugin
       title: Mesh reader
@@ -19,6 +22,9 @@ contributions:
     - command: surforama.thylakoid
       key: thylakoid
       display_name: thylakoid membrane
+    - command: surforama.covid
+      key: covid
+      display_name: covid virion membrane
   readers:
     - command: surforama.mesh_reader
       filename_patterns:


### PR DESCRIPTION
This PR adds the covide sample data and napari as an optional installation (for a one line working surforama installation)

cc @rdrighetto

Closes #12  and #15 