### PR TITLE
Improve initialization

### DIFF
--- a/src/surforama/utils/napari.py
+++ b/src/surforama/utils/napari.py
@@ -61,6 +61,10 @@ def vectors_data_from_points_data(
     up_data : np.ndarray
         The Vectors layer data for the up vectors
     """
+    # check in the points layer has any data
+    if len(point_coordinates) == 0:
+        # if there are no points, there are no vectors
+        return np.empty((0, 2, 3)), np.empty((0, 2, 3))
     # get the vectors
     normal_vectors = features_table[
         [NAPARI_NORMAL_0, NAPARI_NORMAL_1, NAPARI_NORMAL_2]


### PR DESCRIPTION
As discussed in #35 , this PR fixes the initialization behavior of the widgets:
- initializes the surface layer with shading set to `none`
- fixes the re-enabling of the picking layer after a layer has been deleted. the new behavior is that when one of the annotation layers associated with the picking (e.g., points or vectors) is deleted from the viewer, the picking mode is disabled. the user can then re-enable the picking and the layers are re-created.