### PR TITLE
Fix CI: use Python 3.10 for docs job

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,10 +26,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,10 +73,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: tlambert03/setup-qt-libs@v1
       # Install dependencies
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           pip install "PyOpenGL<3.1.7"
@@ -109,9 +109,9 @@ jobs:
     runs-on: ubuntu-22.04
     if: contains(github.ref, 'tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 requires-python = ">=3.10"
@@ -86,7 +86,7 @@ write_to = "src/surforama/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py310', 'py311', 'py312']
 
 
 [tool.ruff]
@@ -132,5 +132,5 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = "py38"
+target-version = "py310"
 fix = true


### PR DESCRIPTION
## Summary

- **Fix docs job failure**: The docs CI job was using Python 3.9, but `pyproject.toml` requires `>=3.10`, causing `pip install ".[docs]"` to fail with a version incompatibility error. Changed to Python 3.10.
- **Update GitHub Actions versions**: Bumped `actions/checkout` from v2 to v4 and `actions/setup-python` from v2 to v5 in the test and deploy jobs (the docs job already used v4/v5).
- **Align metadata with supported versions**: Updated Python classifiers from 3.8/3.9/3.10 to 3.10/3.11/3.12, and updated black/ruff `target-version` from py38 to py310, matching the project's `requires-python = ">=3.10"`.

## Context

The last 3 CI runs (Feb 2025) all failed. The most recent run on `main` (run 22385795318) shows all 9 test matrix jobs passing, but the docs job fails at the "Install dependencies" step because Python 3.9 cannot satisfy `requires-python = ">=3.10"`.

## Test plan

- [ ] CI workflow runs and all jobs pass (tests + docs)
- [ ] Docs build successfully with Python 3.10